### PR TITLE
Add option to use cron within container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER Jeroen Geusebroek <me@jeroengeusebroek.nl>
 
 ENV DEBIAN_FRONTEND="noninteractive" \
     TERM="xterm" \
-    APTLIST="apache2 php7.1 php7.1-curl php7.1-gd php7.1-gmp php7.1-mysql php7.1-xml php7.1-xmlrpc php7.1-mbstring php7.1-zip git-core" \
-    REFRESHED_AT='2017-11-09'
+    APTLIST="apache2 php7.1 php7.1-curl php7.1-gd php7.1-gmp php7.1-mysql php7.1-xml php7.1-xmlrpc php7.1-mbstring php7.1-zip git-core cron" \
+    REFRESHED_AT='2018-03-16'
 
 RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup &&\
     echo "Acquire::http {No-Cache=True;};" > /etc/apt/apt.conf.d/no-cache && \

--- a/README.md
+++ b/README.md
@@ -43,26 +43,35 @@ Please NOTE that the volume is optional. Only necessary when you have special co
 
 You should now be able to reach the spotweb interface on port 80.
 
-### Automatic retreiving of new spots
-
-To enable automatic retreiving, you need to setup a cronjob on the docker host.
+### Automatic retrieval of new spots
+To enable automatic retrieval, you need to setup a cronjob on either the docker host or within the container.
+#### Automatic retrieval of new spots on the docker host
+To enable automatic retrieval, you need to setup a cronjob on the docker host.
 
 	*/15 * * * * docker exec spotweb su -l www-data -s /usr/bin/php /var/www/spotweb/retrieve.php >/dev/null 2>&1
 
 This example will retrieve new spots every 15 minutes.
+#### Automatic retrieval of new spots from within the container
+To enable automatic retrieval from within the container, use the `SPOTWEB_CRON_RETRIEVE` variable to specify the cron timing for retrieval. For example as additional parameter to the `docker run` command:
+
+    -e SPOTWEB_CRON_RETRIEVE='*/15 * * * *'
+
 
 ### Updates
 
 The container will try to auto-update the database when a newer version is released.
 
 ### Environment variables
-
-* `TZ` The timezone the server is running in. Defaults to `Europe/Amsterdam`.
-* `SPOTWEB_DB_TYPE` Database type. Use `pdo_mysql` for MySQL.
-* `SPOTWEB_DB_HOST` The hostname / IP of the database server.
-* `SPOTWEB_DB_NAME` The database used for spotweb.
-* `SPOTWEB_DB_USER` The database server username.
-* `SPOTWEB_DB_PASS` The database server password.
+| Variable | Function |
+| --- | --- |
+| `TZ` | The timezone the server is running in. Defaults to `Europe/Amsterdam`. |
+| `SPOTWEB_DB_TYPE` | Database type. Use `pdo_mysql` for MySQL. |
+| `SPOTWEB_DB_HOST` | The hostname / IP of the database server. |
+| `SPOTWEB_DB_NAME` | The database used for spotweb. |
+| `SPOTWEB_DB_USER` | The database server username. |
+| `SPOTWEB_DB_PASS` | The database server password. |
+| `SPOTWEB_CRON_RETRIEVE` | Cron schedule for article retrieval. E.g. `'*/15 * * * *'` for every fifteen minutes.|
+| `SPOTWEB_CRON_CACHE_CHECK` | Cron schedule for article cache sanity check. E.g. `'10 */1 * * *'` for 10 minutes after every hour. |
 
 ## License
 


### PR DESCRIPTION
This PR allows the scheduling of article retrieval to take place within the spotweb container.