### PR TITLE
Added wget and jq to the apt package install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER Jeroen Geusebroek <me@jeroengeusebroek.nl>
 
 ENV DEBIAN_FRONTEND="noninteractive" \
     TERM="xterm" \
-    APTLIST="apache2 php7.2 php7.2-curl php7.2-gd php7.2-gmp php7.2-mysql php7.2-pgsql php7.2-xml php7.2-xmlrpc php7.2-mbstring php7.2-zip git-core cron" \
-    REFRESHED_AT='2018-04-18'
+    APTLIST="apache2 php7.2 php7.2-curl php7.2-gd php7.2-gmp php7.2-mysql php7.2-pgsql php7.2-xml php7.2-xmlrpc php7.2-mbstring php7.2-zip git-core cron wget jq" \
+    REFRESHED_AT='2020-03-06'
 
 RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup &&\
     echo "Acquire::http {No-Cache=True;};" > /etc/apt/apt.conf.d/no-cache && \


### PR DESCRIPTION
This is to enable scripts to interrogate the sabnzbd API

I was hoping this wasn't necessary, and `APTLIST` could be overridden in the `docker run` command line, but it didn't take. It might be due to my using the Synology Docker UI.

Anyway, I add `wget` and `jq` ([link](https://packages.ubuntu.com/bionic/jq)) so I can use this [script](https://gist.github.com/jamesstout/6832436dd8d06adeb4aba93705ad5c39) to wrap my calls to `retrieve.php`:

```
# If sabnzbd is downloading at the time the spotweb retrieve script runs
# You can get the "Too many connections to server xxxxx.xxx" error.
# The script attempts to pause the sabnzbd queue, 
# then wait for all connections to disconnect before running the spotweb retrieve script.
# Once it completes, the queue is started again (or reverted to initial state). 
```