### PR TITLE
Typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
      - SPOTWEB_DB_PASS=spotweb
      - "SPOTWEB_CRON_RETRIEVE=* */2 * * *"
     depends_on:
-     - spotwebdb
+     - spotweb_db
     ports:
      - 81:80
     volumes:


### PR DESCRIPTION
Service 'spotweb' has a link to service 'spotweb_db' not 'spotwebdb'