### PR TITLE
Adding a github workflow to automate arm docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: Build docker image
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: build the image
+        run: |
+          docker buildx build --push \
+            --tag jgeusebroek/docker-spotweb:latest \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 .


### PR DESCRIPTION
This PR will automate arm docker image build through github actions.

- Go to https://hub.docker.com/settings/security
- New access token
- Give it a name and copy the token

- Go to https://github.com/jgeusebroek/docker-spotweb/settings/secrets/actions

- New repository secret
- Name: DOCKER_USERNAME
- Value: your dockerhub username

- New repository secret
- Name: DOCKER_PASSWORD
- Value: the token you just created on docker hub

You can disable auto building on docker hub after this PR is merged.