### PR TITLE
Improved sed-comments when ran a second time

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ When this all is finished, restart spotweb using `docker-compose restart`. You s
 | `SPOTWEB_DB_PASS` | The database server password. |
 | `SPOTWEB_CRON_RETRIEVE` | Cron schedule for article retrieval. E.g. `*/15 * * * *` for every fifteen minutes.|
 | `SPOTWEB_CRON_CACHE_CHECK` | Cron schedule for article cache sanity check. E.g. `10 */1 * * *` for 10 minutes after every hour. |
+| `WEBSERVER_PORT` | Change the webserver port (for when you can't use port mapping with host network for example)|
 
 ## License
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,8 +64,8 @@ unset rt
 
 # Change Apache port if needed from the default 80 to `WEBSERVER_PORT` (to run unprivileged or with a host network where no port mapping is available)
 if [[ -n "$WEBSERVER_PORT" ]]; then
-    sed -i 's/Listen 80/Listen '"$WEBSERVER_PORT"'/' /etc/apache2/ports.conf
-    sed -i 's/VirtualHost \*:80/VirtualHost \*:'"$WEBSERVER_PORT"'/' /etc/apache2/sites-enabled/000-default.conf
+    sed -i 's/^Listen 80$/Listen '"$WEBSERVER_PORT"'/' /etc/apache2/ports.conf
+    sed -i 's/VirtualHost \*:80>/VirtualHost \*:'"$WEBSERVER_PORT"'>/' /etc/apache2/sites-enabled/000-default.conf
 fi
 
 # Only restart if one of the enmod commands succeeded


### PR DESCRIPTION
I made a small mistake :) When running these commands a second time (e.d. restarting the container without pruning volumes) the commands would be executed again. No problem however except if your port starts with 80.

```
Listen 8090
```

Would become:
```
Listen 809990
```

And the same with the vhost. Any other port not starting with 80 would be fine :) I have updated the sed commands to match on the end of the line (for the `Listen` statement) and on the `>` for the vhost.

I didn't noticed this yesterday as it just worked the first time :) I was playing with it for a bit and at some point the container did not want to start so yeah this was the problem!